### PR TITLE
UWA middleware

### DIFF
--- a/src/Auth/UWAProviderInterface.php
+++ b/src/Auth/UWAProviderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Urbit\Auth;
+
+use Psr\Http\Message\RequestInterface;
+
+interface UWAProviderInterface {
+
+    /**
+     * Return the UWA header
+     *
+     * @param RequestInterface $request
+     * @param string $nonce
+     * @param int $timestamp
+     * @return string
+     */
+    public function getRequestAuthorizationHeader(RequestInterface $request, $nonce = null, $timestamp = null);
+
+}

--- a/src/Request/Middleware.php
+++ b/src/Request/Middleware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Urbit\Request;
+
+use Urbit\Auth\UWAProviderInterface;
+
+class Middleware {
+
+    /**
+     * @param UWAProviderInterface $UWAProvider
+     * @return \Closure
+     */
+    public static function uwaAuth(UWAProviderInterface $UWAProvider) {
+        return function (callable $handler) use ($UWAProvider) {
+            return new UwaAuthMiddleware($handler, $UWAProvider);
+        };
+    }
+
+}

--- a/src/Request/UwaAuthMiddleware.php
+++ b/src/Request/UwaAuthMiddleware.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Urbit\Request;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\RequestInterface;
+use Urbit\Auth\UWAProviderInterface;
+
+class UwaAuthMiddleware {
+
+    /** @var callable */
+    private $nextHandler;
+    /** @var UWAProviderInterface */
+    private $UWAProvider;
+
+    /**
+     * @param callable $nextHandler Next handler to invoke.
+     * @param UWAProviderInterface $UWAProvider
+     */
+    public function __construct(callable $nextHandler, UWAProviderInterface $UWAProvider)
+    {
+        $this->nextHandler = $nextHandler;
+        $this->UWAProvider = $UWAProvider;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param array            $options
+     *
+     * @return PromiseInterface
+     */
+    public function __invoke(RequestInterface $request, array $options)
+    {
+        $modify = [
+            'set_headers' => [
+                'Authorization' => $this->UWAProvider->getRequestAuthorizationHeader($request),
+            ],
+        ];
+
+        $fn = $this->nextHandler;
+        return $fn(\GuzzleHttp\Psr7\modify_request($request, $modify), $options);
+    }
+
+}


### PR DESCRIPTION
I've extracted out the UWA provider into request middleware, as well as make the instance reusable between requests. If another authentication method needs to be implemented (e.g. http basic auth, or oauth token), I think it should be implemented as a separate middleware class.
